### PR TITLE
Fix falsey value for ssl parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ function startServer(port) {
     };
 
     badger.GetCoverage(request.query.server,
-      request.query.ssl,
+      request.query.ssl === 'true',
       request.query.resource,
       request.query.metrics,
       coverageHandler,


### PR DESCRIPTION
Because you check if ssl parameter is present and not true, so passing `ssl=false` acts like `ssl=true` or `ssl=whatever`.

With this PR, only `ssl=true` will be considered true, every other value will fall back to false
