### PR TITLE
Feature/sonar authentication

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ function startServer(port) {
       request.query.ssl,
       request.query.resource,
       request.query.metrics,
+      request.query.token,
       coverageHandler,
       onError);
 

--- a/src/lib/badger.js
+++ b/src/lib/badger.js
@@ -20,10 +20,14 @@ var colorSettings = [{
 }];
 
 function getCoverage(host, ssl, resource, metric, success, error) {
-  var fulluri = 'http' + (ssl ? 's' : '') + '://' + host + '/api/resources?resource=' + resource + '&metrics=' + metric;
   var httplib = ssl ? https : http;
 
-  httplib.get(fulluri, function(res) {
+  var options = {
+    hostname: host,
+    path: '/api/resources?resource=' + resource + '&metrics=' + metric
+  };
+
+  httplib.get(options, function(res) {
     var str = '';
     res.setEncoding('utf8');
     res.on('data', function(chunk) {

--- a/src/lib/badger.js
+++ b/src/lib/badger.js
@@ -19,13 +19,17 @@ var colorSettings = [{
   color: '#4c1'
 }];
 
-function getCoverage(host, ssl, resource, metric, success, error) {
+function getCoverage(host, ssl, resource, metric, token, success, error) {
   var httplib = ssl ? https : http;
 
   var options = {
     hostname: host,
     path: '/api/resources?resource=' + resource + '&metrics=' + metric
   };
+
+  if (token) {
+    options.auth = token + ':';
+  }
 
   httplib.get(options, function(res) {
     var str = '';

--- a/test/badger.test.js
+++ b/test/badger.test.js
@@ -34,6 +34,19 @@ describe('Badger', function() {
       });
   });
 
+  it('should get code coverage value using an access token', function(done) {
+
+    badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage', 'fake-token',
+      function(d) { // success
+        d.should.above(90);
+        done();
+      },
+      function(e) { // error
+        assert.fail("Error occurred" + e);
+        done();
+      });
+  });
+
   it('should get code coverage value for SSL', function(done) {
 
     badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage', false,

--- a/test/badger.test.js
+++ b/test/badger.test.js
@@ -23,7 +23,7 @@ describe('Badger', function() {
 
   it('should get code coverage value', function(done) {
 
-    badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage',
+    badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage', false,
       function(d) { // success
         d.should.above(90);
         done();
@@ -36,7 +36,7 @@ describe('Badger', function() {
 
   it('should get code coverage value for SSL', function(done) {
 
-    badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage',
+    badger.GetCoverage('nemo.sonarqube.org', true, phpProjectKey, 'coverage', false,
       function(d) { // success
         d.should.above(90);
         done();
@@ -48,7 +48,7 @@ describe('Badger', function() {
   });
 
   it('should return parsed error', function(done) {
-    badger.GetCoverage('test', true, 'fdsfdasafd', 'afdasfsd', undefined,
+    badger.GetCoverage('test', true, 'fdsfdasafd', 'afdasfsd', undefined, false,
       function(e) { // error
         assert.include(e.toString(), 'ENOTFOUND');
         done();
@@ -57,7 +57,7 @@ describe('Badger', function() {
 
   it('should handle an error', function(done) {
 
-    badger.GetCoverage('127.0.0.1', undefined, 'none', 'none', undefined,
+    badger.GetCoverage('127.0.0.1', undefined, 'none', 'none', undefined, false,
       function(e) { // error
         assert.include(e.toString(), 'ECONNREFUSED');
         done();
@@ -67,7 +67,7 @@ describe('Badger', function() {
   it('should not call success when metric does not exist', function(done) {
     var metric = 'FAIL';
 
-    badger.GetCoverage('nemo.sonarqube.org', undefined, phpProjectKey, metric,
+    badger.GetCoverage('nemo.sonarqube.org', undefined, phpProjectKey, metric, false,
       function() {
         assert.fail('Success should not be called for bad values');
         done();


### PR DESCRIPTION
Add token handling in parameters to be allowed to access protected endpoint URLs

Sample URL: `http://localhost:8087/?server=sonar.host&token=sonar-access-token&resource=project-resource&metrics=coverage&ssl=false`

Token documentation: http://docs.sonarqube.org/display/SONAR/User+Token
